### PR TITLE
Add Per-Service Annotations to Chart

### DIFF
--- a/chart/flux-web/templates/service-backend.yaml
+++ b/chart/flux-web/templates/service-backend.yaml
@@ -7,6 +7,12 @@ metadata:
   {{- end }}
   labels:
 {{ include "flux-web.labels" . | indent 4 }}
+  {{- if .Values.backend.service.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.backend.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end -}}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/chart/flux-web/templates/service-frontend.yaml
+++ b/chart/flux-web/templates/service-frontend.yaml
@@ -7,11 +7,17 @@ metadata:
   {{- end }}
   labels:
 {{ include "flux-web.labels" . | indent 4 }}
+  {{- if .Values.frontend.service.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.frontend.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end -}}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort:  {{ .Values.frontend.containerPort }}
+      targetPort: {{ .Values.frontend.containerPort }}
       protocol: TCP
       name: http
   selector:

--- a/chart/flux-web/values.yaml
+++ b/chart/flux-web/values.yaml
@@ -14,6 +14,8 @@ backend:
   containerPort: 3000
   env:
     FLUX_URL: http://flux:3030
+  service: {}
+    # annotations: ""
 frontend:
   repository: fluxweb/frontend
   tag: 0.1
@@ -22,6 +24,8 @@ frontend:
   env:
     API_EXTERNAL_URL: //flux-web.local/api/v1
     WS_URL: ws://flux-web.local/ws/v1
+  service: {}
+    # annotations: ""
     
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
This change supports the use case where different annotations need to be applied to the Helm chart's `Service`s.

This is required in our case to have the ALB Ingress Controller use different health check paths per target group (see: https://github.com/kubernetes-sigs/aws-alb-ingress-controller/pull/423 and https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/93#issuecomment-473679642). 