### PR TITLE
Add Optional Ingress Redirect

### DIFF
--- a/chart/flux-web/templates/ingress.yaml
+++ b/chart/flux-web/templates/ingress.yaml
@@ -24,6 +24,14 @@ spec:
   {{- end }}
 {{- end }}
   rules:
+  {{- if .Values.ingress.redirect.enabled }}
+    - http:
+        paths:
+        - backend:
+            serviceName: redirect
+            servicePort: use-annotation
+          path: {{ .Values.ingress.redirect.path }}
+  {{- end -}}
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:

--- a/chart/flux-web/values.yaml
+++ b/chart/flux-web/values.yaml
@@ -45,6 +45,9 @@ ingress:
         - frontend: /
         - backend: /api
         - backend: /ws
+  redirect:
+    enabled: false
+    # path: "/*"
 
 
   tls: []


### PR DESCRIPTION
This adds an optional section to the ingress template that is required to do HTTPS redirection with the ALB Ingress Controller (see: https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/).