### PR TITLE
optional ingress output

### DIFF
--- a/chart/flux-web/templates/ingress.yaml
+++ b/chart/flux-web/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 {{- $fullName := include "flux-web.fullname" . -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -45,3 +46,4 @@ spec:
         {{- end }}
         {{- end }}
   {{- end }}
+{{- end }}


### PR DESCRIPTION
This adds a Values option to make the ingress optional when deploying the chart. Useful for those who, like myself, already have an ingress stood up and can point it to the flux-web services.